### PR TITLE
fix: corrected Spanish translation of UX/UI in footer

### DIFF
--- a/src/intl/es/common.json
+++ b/src/intl/es/common.json
@@ -239,7 +239,7 @@
   "nav-did-description": "Cree y sea propietario de sus identificadores descentralizados propios",
   "nav-docs-description": "Documentación de ayuda para entender y construir en Ethereum",
   "nav-docs-design-description": "Descripción de los retos de diseño únicos de Web3, mejores prácticas y hallazgos de investigaciones de los usuarios",
-  "nav-docs-design-label": "Lo esencial del diseño de la UX/IU",
+  "nav-docs-design-label": "Lo esencial del diseño de la UX/UI",
   "nav-docs-foundation-description": "Los fundamentos para desarrollar en Ethereum",
   "nav-docs-foundation-label": "Temas fundamentales",
   "nav-docs-overview-description": "El sitio donde buscar documentación para desarrolladores",


### PR DESCRIPTION
# Fix Spanish Translation of UX/UI in Footer Section

## Description
This PR fixes the translation error in the Spanish version footer, correcting "UX/IU" to "UX/UI". While "IU" (Interfaz de Usuario) is the correct Spanish abbreviation for User Interface, the globally recognized standard order is "UX/UI" even in Spanish-speaking contexts.

## Changes Made
- Changed "Lo esencial del diseño de la UX/IU" to "Lo esencial del diseño de la UX/UI" in `src/intl/es/common.json`

## Additional Context
As pointed out in the issue, although "IU" is technically the correct abbreviation in Spanish, "UX/UI" has become the internationally recognized standard order used in technical and design fields, including in Spanish-speaking environments. This change aligns the translation with industry conventions, improving professionalism and consistency.