### PR TITLE
Fix rlp example

### DIFF
--- a/public/content/community/research/index.md
+++ b/public/content/community/research/index.md
@@ -41,7 +41,7 @@ As well as forward-looking research, some fundamental redesigns of the protocol,
 
 - [Introduction to proof-of-stake](/developers/docs/consensus-mechanisms/pos/)
 - [Casper-FFG paper](https://arxiv.org/abs/1710.09437)
-- [Casper-FFG explainer](https://arxiv.org/abs/1710.09437)
+- [Casper-FFG explainer](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Gasper paper](https://arxiv.org/abs/2003.03052)
 
 #### Recent research {#recent-research}

--- a/public/content/translations/cs/community/research/index.md
+++ b/public/content/translations/cs/community/research/index.md
@@ -41,7 +41,7 @@ Kromě výzkumu zaměřeného na budoucnost se zkoumají i některé zásadní z
 
 - [Úvod do důkazu podílem](/developers/docs/consensus-mechanisms/pos/)
 - [Práce na Casper-FFG](https://arxiv.org/abs/1710.09437)
-- [Vysvětlení Casper-FFG](https://arxiv.org/abs/1710.09437)
+- [Vysvětlení Casper-FFG](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Práce na Casper](https://arxiv.org/abs/2003.03052)
 
 #### Nedávný výzkum {#recent-research}

--- a/public/content/translations/de/community/research/index.md
+++ b/public/content/translations/de/community/research/index.md
@@ -41,7 +41,7 @@ Genau wie zukunftsorientierte Forschung werden einige fundamentale Neugestaltung
 
 - [Einführung in Proof-of-Stake](/developers/docs/consensus-mechanisms/pos/)
 - [Casper-FFG-Artikel](https://arxiv.org/abs/1710.09437)
-- [Casper-FFG-Erklärung](https://arxiv.org/abs/1710.09437)
+- [Casper-FFG-Erklärung](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Casper-Artikel](https://arxiv.org/abs/2003.03052)
 
 #### Aktuelle Forschung {#recent-research}

--- a/public/content/translations/el/community/research/index.md
+++ b/public/content/translations/el/community/research/index.md
@@ -41,7 +41,7 @@ lang: el
 
 - [Είσοδος στην απόδειξη συμμετοχής](/developers/docs/consensus-mechanisms/pos/)
 - [Έγγραφο Casper-FFG](https://arxiv.org/abs/1710.09437)
-- [Εξήγηση Casper-FFG](https://arxiv.org/abs/1710.09437)
+- [Εξήγηση Casper-FFG](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Έγγραφο Gasper](https://arxiv.org/abs/2003.03052)
 
 #### Πρόσφατη έρευνα {#recent-research}

--- a/public/content/translations/es/community/research/index.md
+++ b/public/content/translations/es/community/research/index.md
@@ -41,7 +41,7 @@ Además de la investigación de perspectivas futuras, se están investigando alg
 
 - [Introducción a prueba de participación](/developers/docs/consensus-mechanisms/pos/)
 - [Documento Casper-FFG](https://arxiv.org/abs/1710.09437)
-- [Explicación de Casper-FFG](https://arxiv.org/abs/1710.09437)
+- [Explicación de Casper-FFG](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Documento de Gasper](https://arxiv.org/abs/2003.03052)
 
 #### Investigación reciente {#recent-research}

--- a/public/content/translations/fa/community/research/index.md
+++ b/public/content/translations/fa/community/research/index.md
@@ -41,7 +41,7 @@ lang: fa
 
 - [Introduction to proof-of-stake](/developers/docs/consensus-mechanisms/pos/)
 - [Casper-FFG paper](https://arxiv.org/abs/1710.09437)
-- [توضیح‌دهنده Casper-FFG](https://arxiv.org/abs/1710.09437)
+- [توضیح‌دهنده Casper-FFG](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Gasper paper](https://arxiv.org/abs/2003.03052)
 
 #### جدیدترین تحقیقات {#recent-research}

--- a/public/content/translations/fr/community/research/index.md
+++ b/public/content/translations/fr/community/research/index.md
@@ -39,9 +39,9 @@ Outre des recherches prospectives, certaines refontes fondamentales du protocole
 
 #### Lecture de fond {#background-reading}
 
-- Introduction à la preuve d'enjeu](/developers/docs/consensus-mechanisms/pos/)
+- [Introduction à la preuve d'enjeu](/developers/docs/consensus-mechanisms/pos/)
 - [Article Casper-FFG](https://arxiv.org/abs/1710.09437)
-- [Explication Casper-FFG](https://arxiv.org/abs/1710.09437)
+- [Explication Casper-FFG](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Article Gasper](https://arxiv.org/abs/2003.03052)
 
 #### Recherche récente {#recent-research}

--- a/public/content/translations/fr/developers/docs/data-structures-and-encoding/rlp/index.md
+++ b/public/content/translations/fr/developers/docs/data-structures-and-encoding/rlp/index.md
@@ -80,7 +80,7 @@ def to_binary(x):
 - l'octet '\\x00' = `[ 0x00 ]`
 - l'octet '\\x0f' = `[ 0x0f ]`
 - les octets '\\x04\\x00' = `[ 0x82, 0x04, 0x00 ]`
-- la [représentation théorique en théorie des ensembles](https://fr.wikipedia.org/wiki/Construction_des_entiers_naturels) de trois, `[ [], [[]], [ [], [[]] ] ] = [ 0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc0, 0xc1, 0xc0 ]`
+- la [représentation théorique en théorie des ensembles](https://fr.wikipedia.org/wiki/Construction_des_entiers_naturels) de trois, `[ [], [[]], [ [], [[]] ] ] = [ 0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0 ]`
 - la chaîne de caractères "Lorem ipsum dolor sit amet, consectetur adipisicing elit" = `[ 0xb8, 0x38, 'L', 'o', 'r', 'e', 'm', ' ', ... , 'e', 'l', 'i', 't' ]`
 
 ## Décodage RLP {#rlp-decoding}

--- a/public/content/translations/hu/community/research/index.md
+++ b/public/content/translations/hu/community/research/index.md
@@ -41,7 +41,7 @@ Emellett a jövőbe előretekintő kutatások, a protokoll alapvető újratervez
 
 - [Bevezetés a proof-of-stake mechanizmusba](/developers/docs/consensus-mechanisms/pos/)
 - [Casper-FFG dokumentáció](https://arxiv.org/abs/1710.09437)
-- [Casper-FFG magyarázat](https://arxiv.org/abs/1710.09437)
+- [Casper-FFG magyarázat](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Gasper dokumentáció](https://arxiv.org/abs/2003.03052)
 
 #### Jelenlegi kutatás {#recent-research}

--- a/public/content/translations/it/community/research/index.md
+++ b/public/content/translations/it/community/research/index.md
@@ -41,7 +41,7 @@ Oltre alla ricerca prospettica, si stanno studiando alcune riprogettazioni fonda
 
 - [Introduzione al proof-of-stake](/developers/docs/consensus-mechanisms/pos/)
 - [Documento Casper-FFG](https://arxiv.org/abs/1710.09437)
-- [Spiegazione di Casper-FFG](https://arxiv.org/abs/1710.09437)
+- [Spiegazione di Casper-FFG](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Documento Gasper](https://arxiv.org/abs/2003.03052)
 
 #### Ricerca recente {#recent-research}

--- a/public/content/translations/ja/community/research/index.md
+++ b/public/content/translations/ja/community/research/index.md
@@ -41,7 +41,7 @@ lang: ja
 
 - [プルーフ・オブ・ステーク入門](/developers/docs/consensus-mechanisms/pos/)
 - [Casper-FFG ペーパー](https://arxiv.org/abs/1710.09437)
-- [Casper-FFG の解説](https://arxiv.org/abs/1710.09437)
+- [Casper-FFG の解説](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Gasper ペーパー](https://arxiv.org/abs/2003.03052)
 
 #### 最近の研究 {#recent-research}

--- a/public/content/translations/pl/community/research/index.md
+++ b/public/content/translations/pl/community/research/index.md
@@ -41,7 +41,7 @@ Oprócz badań wybiegających w przyszłość, badane są niektóre fundamentaln
 
 - [Wprowadzenie do proof-of-stake](/developers/docs/consensus-mechanisms/pos/)
 - [Dokument Casper-FPG](https://arxiv.org/abs/1710.09437)
-- [Objaśnienie Casper-FFG](https://arxiv.org/abs/1710.09437)
+- [Objaśnienie Casper-FFG](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Dokument Gasper](https://arxiv.org/abs/2003.03052)
 
 #### Ostatnie badania {#recent-research}

--- a/public/content/translations/pt-br/community/research/index.md
+++ b/public/content/translations/pt-br/community/research/index.md
@@ -41,7 +41,7 @@ Além da pesquisa voltada para o futuro, algumas reformulações fundamentais do
 
 - [Introdução à prova de participação](/developers/docs/consensus-mechanisms/pos/)
 - [Artigo sobre o Casper-FFG](https://arxiv.org/abs/1710.09437)
-- [Artigo sobre Casper-FFG](https://arxiv.org/abs/1710.09437)
+- [Artigo sobre Casper-FFG](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Artigo sobre o Gasper](https://arxiv.org/abs/2003.03052)
 
 #### Pesquisa recente {#recent-research}

--- a/public/content/translations/pt-br/developers/docs/data-structures-and-encoding/rlp/index.md
+++ b/public/content/translations/pt-br/developers/docs/data-structures-and-encoding/rlp/index.md
@@ -80,7 +80,7 @@ def to_binary(x):
 - o byte '\\x00' = `[ 0x00 ]`
 - o byte '\\x0f' = `[ 0x0f ]`
 - os bytes '\\x04\\x00' = `[ 0x82, 0x04, 0x00 ]`
-- [define a representação teórica](http://en.wikipedia.org/wiki/Set-theoretic_definition_of_natural_numbers) para três, `[ [], [[]], [ [], [[]] ] ] = [ 0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc0, 0xc1, 0xc0 ]`
+- [define a representação teórica](http://en.wikipedia.org/wiki/Set-theoretic_definition_of_natural_numbers) para três, `[ [], [[]], [ [], [[]] ] ] = [ 0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0 ]`
 - a string "Lorem ipsum dolor sit amet, consectetur adipisicing elit" = `[ 0xb8, 0x38, 'L', 'o', 'r', 'e', 'm', ' ', ... , 'e', 'l', 'i', 't' ]`
 
 ## Decodificação RLP {#rlp-decoding}

--- a/public/content/translations/ru/community/research/index.md
+++ b/public/content/translations/ru/community/research/index.md
@@ -41,7 +41,7 @@ lang: ru
 
 - [Введение в доказательство доли владения](/developers/docs/consensus-mechanisms/pos/)
 - [Документ Casper-FFG](https://arxiv.org/abs/1710.09437)
-- [Поясняющая статья Casper-FFG](https://arxiv.org/abs/1710.09437)
+- [Поясняющая статья Casper-FFG](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Документ Gasper](https://arxiv.org/abs/2003.03052)
 
 #### Недавние исследования {#recent-research}

--- a/public/content/translations/tr/community/research/index.md
+++ b/public/content/translations/tr/community/research/index.md
@@ -41,7 +41,7 @@ Mutabakat araştırması, [Ethereum'un hisse ispatı mekanizması](/developers/d
 
 - [Hisse ispatına giriş](/developers/docs/consensus-mechanisms/pos/)
 - [Casper-FFG makalesi](https://arxiv.org/abs/1710.09437)
-- [Casper-FFG açıklayıcısı](https://arxiv.org/abs/1710.09437)
+- [Casper-FFG açıklayıcısı](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Gasper makalesi](https://arxiv.org/abs/2003.03052)
 
 #### Yakın geçmişteki araştırmalar {#recent-research}

--- a/public/content/translations/zh-tw/community/research/index.md
+++ b/public/content/translations/zh-tw/community/research/index.md
@@ -41,7 +41,7 @@ lang: zh-tw
 
 - [權益證明簡介](/developers/docs/consensus-mechanisms/pos/)
 - [Casper-FFG paper](https://arxiv.org/abs/1710.09437)
-- [Casper-FFG 說明](https://arxiv.org/abs/1710.09437)
+- [Casper-FFG 說明](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Gasper 論文](https://arxiv.org/abs/2003.03052)
 
 #### 近期研究 {#recent-research}

--- a/public/content/translations/zh/community/research/index.md
+++ b/public/content/translations/zh/community/research/index.md
@@ -41,7 +41,7 @@ lang: zh
 
 - [权益证明简介](/developers/docs/consensus-mechanisms/pos/)
 - [Casper-FFG 论文](https://arxiv.org/abs/1710.09437)
-- [Casper-FFG 的解释说明](https://arxiv.org/abs/1710.09437)
+- [Casper-FFG 的解释说明](https://medium.com/unitychain/intro-to-casper-ffg-9ed944d98b2d)
 - [Gasper 论文](https://arxiv.org/abs/2003.03052)
 
 #### 近期的研究 {#recent-research}


### PR DESCRIPTION
# Fix RLP encoding example in French and Portuguese-Brazilian translations

## Description
This PR fixes an error in the RLP encoding documentation for both French (fr) and Portuguese-Brazilian (pt-br) translations. In these translations, the RLP encoding example for the set-theoretic representation of three `[ [], [[]], [ [], [[]] ] ]` contained an extra `0xc0` byte.

## Changes
- Removed the extra `0xc0` byte from the French version
- Removed the extra `0xc0` byte from the Portuguese-Brazilian version

The corrected encoding now matches the English version:
[ 0xc7, 0xc0, 0xc1, 0xc0, 0xc3, 0xc0, 0xc1, 0xc0 ]